### PR TITLE
fix: correct humidity scaling from tenths to percentage

### DIFF
--- a/custom_components/rixens/api.py
+++ b/custom_components/rixens/api.py
@@ -68,7 +68,7 @@ class RixensData:
     engine_state: int
     glycol_state: int
     current_temp: float  # Temperature in Celsius
-    current_humidity: int
+    current_humidity: float  # Humidity in percent
     heater: RixensHeaterData
     settings: RixensSettings
 
@@ -216,7 +216,7 @@ class RixensApi:
             engine_state=get_int(root, "enginestate"),
             glycol_state=get_int(root, "glycolstate"),
             current_temp=get_int(root, "currenttemp") / 10.0,
-            current_humidity=get_int(root, "currenthumidity"),
+            current_humidity=get_int(root, "currenthumidity") / 10.0,
             heater=heater_data,
             settings=settings,
         )


### PR DESCRIPTION
The Rixens device API reports humidity values in tenths (e.g., 550 for 55.0%), similar to temperature values. This PR adds the missing division by 10 to correctly scale humidity values for display in Home Assistant.

### Changes
- Updated `current_humidity` type from `int` to `float` in RixensData dataclass
- Added `/10.0` scaling when parsing `currenthumidity` from XML

Fixes #15

Generated with [Claude Code](https://claude.ai/code)