### PR TITLE
Add fuel consumption sensor

### DIFF
--- a/custom_components/rixens/sensor.py
+++ b/custom_components/rixens/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     UnitOfLength,
     UnitOfTemperature,
     UnitOfTime,
+    UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -140,6 +141,14 @@ SENSOR_DESCRIPTIONS: tuple[RixensSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.heater.dosing_pump,
+    ),
+    RixensSensorEntityDescription(
+        key="fuel_consumption",
+        translation_key="fuel_consumption",
+        native_unit_of_measurement=f"{UnitOfVolume.MILLILITERS}/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: round(data.heater.dosing_pump * 72, 2) if data.heater.dosing_pump else 0,
     ),
     RixensSensorEntityDescription(
         key="heater_state",

--- a/custom_components/rixens/strings.json
+++ b/custom_components/rixens/strings.json
@@ -56,6 +56,9 @@
       "dosing_pump": {
         "name": "Dosing pump"
       },
+      "fuel_consumption": {
+        "name": "Fuel consumption"
+      },
       "heater_state": {
         "name": "Heater state"
       },

--- a/custom_components/rixens/translations/en.json
+++ b/custom_components/rixens/translations/en.json
@@ -56,6 +56,9 @@
       "dosing_pump": {
         "name": "Dosing pump"
       },
+      "fuel_consumption": {
+        "name": "Fuel consumption"
+      },
       "heater_state": {
         "name": "Heater state"
       },


### PR DESCRIPTION
Implements fuel consumption calculation from dosing pump frequency.

Converts the Espar dosing pump frequency (Hz) to fuel consumption in ml/hour using the formula: ml/hour = Hz × 72.

This is based on typical Espar dosing pump specifications of 0.02 ml per stroke.

Fixes #17

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/crbn60/ha-rixens-integration/actions/runs/21081962955