### PR TITLE
fix: Use system_heat property for climate control state

### DIFF
--- a/custom_components/rixens/climate.py
+++ b/custom_components/rixens/climate.py
@@ -22,7 +22,6 @@ from .const import (
     FAN_SPEED_AUTO,
     FAN_SPEED_MAX,
     FAN_SPEED_MIN,
-    HEATER_STATE_OFF,
     TEMP_MAX,
     TEMP_MIN,
 )
@@ -98,15 +97,12 @@ class RixensClimate(CoordinatorEntity[RixensCoordinator], ClimateEntity):
         if not self.coordinator.data:
             return None
 
-        if not self.coordinator.data.system_heat:
-            return HVACAction.OFF
-
-        # Check if heater is actively heating by looking at heat_on flag
-        # and heater_state (should be non-zero when running)
-        if self.coordinator.data.heater.heat_on and self.coordinator.data.heater.heater_state != HEATER_STATE_OFF:
+        # Use system_heat property from status.xml to determine heating state
+        # When system_heat is true, the system is actively heating
+        if self.coordinator.data.system_heat:
             return HVACAction.HEATING
 
-        return HVACAction.IDLE
+        return HVACAction.OFF
 
     @property
     def fan_mode(self) -> str | None:


### PR DESCRIPTION
Use the system_heat property from status.xml to determine heating state
instead of inferring it from heater.heat_on and heater.heater_state.
This provides accurate heating status directly from the device.

- Simplified hvac_action to check system_heat property directly
- Removed unused HEATER_STATE_OFF import
- When system_heat is true, action is HEATING
- When system_heat is false, action is OFF

Fixes #19

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/crbn60/ha-rixens-integration/actions/runs/21093612694) | [Branch](https://github.com/crbn60/ha-rixens-integration/tree/claude/issue-19-20260117-1133