### PR TITLE
feat: Make temperature presets user-configurable via options flow

### DIFF
--- a/custom_components/rixens/__init__.py
+++ b/custom_components/rixens/__init__.py
@@ -27,7 +27,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register update listener for options changes
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     return True
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/rixens/strings.json
+++ b/custom_components/rixens/strings.json
@@ -18,6 +18,19 @@
       "already_configured": "Device is already configured"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Preset Temperatures",
+        "description": "Configure temperature presets for Away, Home, and Sleep modes.",
+        "data": {
+          "preset_away_temp": "Away temperature (°C)",
+          "preset_home_temp": "Home temperature (°C)",
+          "preset_sleep_temp": "Sleep temperature (°C)"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "current_temperature": {

--- a/custom_components/rixens/translations/en.json
+++ b/custom_components/rixens/translations/en.json
@@ -18,6 +18,19 @@
       "already_configured": "Device is already configured"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Preset Temperatures",
+        "description": "Configure temperature presets for Away, Home, and Sleep modes.",
+        "data": {
+          "preset_away_temp": "Away temperature (°C)",
+          "preset_home_temp": "Home temperature (°C)",
+          "preset_sleep_temp": "Sleep temperature (°C)"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "current_temperature": {


### PR DESCRIPTION
## Summary
Add configuration options for users to customize preset temperatures (Away, Home, Sleep) instead of using hardcoded values.

## Implementation

### Options Flow (`config_flow.py`)
- Added `RixensOptionsFlowHandler` class
- Form with three number inputs for preset temperatures
- Range validation: 5.0-30.0°C
- Default values: Away=10°C, Home=20°C, Sleep=18°C

### Climate Entity (`climate.py`)
- Reads preset temperatures from `config_entry.options`
- Falls back to defaults if options not set (backward compatibility)
- Preset temps stored in instance variable

### Integration (`__init__.py`)
- Added options update listener
- Reloads integration when options change
- Changes apply immediately

### Translations
- Added options form strings to `strings.json` and `translations/en.json`

## User Experience

**Configuration**: Settings → Devices & Services → Rixens → Configure

**Form shows**:
```
Preset Temperatures
───────────────────
Away temperature (°C):  [10.0]  (5-30°C range)
Home temperature (°C):  [20.0]  (5-30°C range)
Sleep temperature (°C): [18.0]  (5-30°C range)

[Submit]
```

## Benefits
- **Cold climates**: Set Away to 7°C for freeze protection
- **Warm preference**: Set Home to 22°C for comfort
- **Sleep comfort**: Customize to individual preference
- **Persistent**: Stored in config entry options

## Backward Compatibility
✅ Existing installations use default values (10, 20, 18°C)
✅ No breaking changes
✅ Options form appears with current defaults

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)