### PR TITLE
Fix HVAC logic to only use actual heat sources

### DIFF
--- a/custom_components/rixens/switch.py
+++ b/custom_components/rixens/switch.py
@@ -31,21 +31,21 @@ SWITCH_DESCRIPTIONS: tuple[RixensSwitchEntityDescription, ...] = (
     RixensSwitchEntityDescription(
         key="furnace",
         translation_key="furnace",
-        value_fn=lambda data: data.settings.furnace_src == 2,  # 2 = active
+        value_fn=lambda data: data.settings.furnace_src != 0,  # 0 = disabled, 1 = enabled, 2 = active
         turn_on_fn=lambda api: api.set_furnace(True),
         turn_off_fn=lambda api: api.set_furnace(False),
     ),
     RixensSwitchEntityDescription(
         key="floor_heat",
         translation_key="floor_heat",
-        value_fn=lambda data: data.settings.floor_src == 2,  # 2 = active
+        value_fn=lambda data: data.settings.floor_src != 0,  # 0 = disabled, 1 = enabled, 2 = active
         turn_on_fn=lambda api: api.set_floor_heat(True),
         turn_off_fn=lambda api: api.set_floor_heat(False),
     ),
     RixensSwitchEntityDescription(
         key="electric_heat",
         translation_key="electric_heat",
-        value_fn=lambda data: data.settings.electric_src == 2,  # 2 = active
+        value_fn=lambda data: data.settings.electric_src != 0,  # 0 = disabled, 1 = enabled, 2 = active
         turn_on_fn=lambda api: api.set_electric_heat(True),
         turn_off_fn=lambda api: api.set_electric_heat(False),
     ),


### PR DESCRIPTION
### Summary

Corrects the climate entity to only use the three actual heat sources (furnace, electric, engine) for HVAC mode and action logic. Floor heat is now correctly excluded from HVAC state determination.

### Changes

- HVAC mode checks if any of furnace_src, electric_src, or engine_src are enabled (!= 0)
- HVAC action correctly distinguishes OFF/IDLE/HEATING based on the three heat sources
- Removed floor_src from all HVAC logic (floor heat is not an HVAC heat source)
- Switch entities now show ON when enabled (!= 0) instead of only when active (== 2)
- Added engine heat support throughout climate entity
- Updated extra_state_attributes to show both enabled and active states for all three heat sources

Fixes #46

---

Generated with [Claude Code](https://claude.ai/code)