### PR TITLE
Fix flame temperature scaling (divide by 100, not 10)

### DIFF
--- a/custom_components/rixens/api.py
+++ b/custom_components/rixens/api.py
@@ -216,14 +216,15 @@ class RixensApi:
             return get_int(parent, tag, 1 if default else 0) == 1
 
         # Parse heater1 data
-        # Note: All temperatures from API are in tenths of a degree Celsius
+        # Note: Most temperatures from API are in tenths of a degree Celsius
+        # Exception: flame_temp is in hundredths of a degree Celsius
         heater1 = root.find("heater1")
         heater_data = RixensHeaterData(
             heat_on=get_bool(heater1, "heaton") if heater1 is not None else False,
             battery_voltage=get_int(heater1, "battv") / 10.0 if heater1 is not None else 0.0,
             runtime=get_int(heater1, "runtime") if heater1 is not None else 0,
             pid_speed=get_int(heater1, "pidspeed") if heater1 is not None else 0,
-            flame_temp=get_int(heater1, "flametemp") / 10.0 if heater1 is not None else 0.0,
+            flame_temp=get_int(heater1, "flametemp") / 100.0 if heater1 is not None else 0.0,
             inlet_temp=get_int(heater1, "inlettemp") / 100.0 if heater1 is not None else 0.0,
             outlet_temp=get_int(heater1, "outlettemp") / 100.0 if heater1 is not None else 0.0,
             atmospheric_pressure=get_float(heater1, "altitude") if heater1 is not None else 0.0,  # XML field "altitude" is actually pressure in hPa


### PR DESCRIPTION
## Summary

Corrected the flame temperature scaling issue. The API provides flame temperature in hundredths of a degree Celsius (1/100), not tenths (1/10) like other temperature values.

## Changes

- Updated flame_temp parsing to divide by 100.0 in `api.py`
- Added clarifying comment about the scaling difference

Fixes #48

---
Generated with [Claude Code](https://claude.ai/code)