### PR TITLE
Fix TypeError in config flow reconfigure

### DIFF
--- a/custom_components/rixens/config_flow.py
+++ b/custom_components/rixens/config_flow.py
@@ -105,6 +105,10 @@ class RixensConfigFlow(ConfigFlow, domain=DOMAIN):
 class RixensOptionsFlowHandler(OptionsFlow):
     """Handle options flow for Rixens integration."""
 
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:


### PR DESCRIPTION
## Summary
- Fix TypeError when attempting to reconfigure the integration
- Add __init__ method to RixensOptionsFlowHandler to accept config_entry parameter

## Problem
When users try to reconfigure an existing integration (e.g., to change IP address or port), they encounter a 500 Internal Server Error with the following traceback:
```
TypeError: RixensOptionsFlowHandler() takes no arguments
```

## Root Cause
The `RixensOptionsFlowHandler` class inherits from `OptionsFlow` but doesn't define an `__init__` method. When `async_get_options_flow` (line 76) tries to instantiate it with a `config_entry` parameter, Python raises a TypeError.

## Solution
Added an `__init__` method to `RixensOptionsFlowHandler` that:
- Accepts the `config_entry` parameter
- Stores it as `self.config_entry` for use in `async_step_init`

This follows the standard Home Assistant pattern for OptionsFlow handlers.

## Test Plan
- [ ] Restart Home Assistant with the updated code
- [ ] Attempt to reconfigure an existing Rixens integration
- [ ] Verify the options flow loads without error
- [ ] Verify options can be updated successfully

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)