### PR TITLE
Fix config flow reconfigure AttributeError

### DIFF
--- a/custom_components/rixens/config_flow.py
+++ b/custom_components/rixens/config_flow.py
@@ -73,7 +73,7 @@ class RixensConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return RixensOptionsFlowHandler(config_entry)
+        return RixensOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -104,10 +104,6 @@ class RixensConfigFlow(ConfigFlow, domain=DOMAIN):
 
 class RixensOptionsFlowHandler(OptionsFlow):
     """Handle options flow for Rixens integration."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- Fix AttributeError when attempting to reconfigure the integration
- Correctly implement OptionsFlow pattern without custom __init__ method

## Problem
When users try to reconfigure an existing integration, they encounter a 500 Internal Server Error. Initial fix attempt caused:
```
AttributeError: property 'config_entry' of 'RixensOptionsFlowHandler' object has no setter
```

## Root Cause
The `OptionsFlow` base class provides `config_entry` as a **read-only property** that's set by the flow manager after instantiation. Attempting to set it in `__init__` or pass it to the constructor causes an AttributeError.

## Solution
- Removed custom `__init__` method from `RixensOptionsFlowHandler`
- Changed `async_get_options_flow` to return `RixensOptionsFlowHandler()` without arguments
- The `config_entry` property is automatically available via the `OptionsFlow` base class

This follows the standard Home Assistant pattern where the flow manager sets the `config_entry` property after creating the flow instance.

## Test Plan
- [ ] Restart Home Assistant with the updated code
- [ ] Attempt to reconfigure an existing Rixens integration
- [ ] Verify the options flow loads without error
- [ ] Verify options can be updated successfully

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)