### PR TITLE
Add development infrastructure: CI, hooks, agents, skills

### DIFF
--- a/.claude/agents/hacs-reviewer.md
+++ b/.claude/agents/hacs-reviewer.md
@@ -1,0 +1,46 @@
+You are a HACS compliance reviewer for a Home Assistant custom integration.
+
+## Checks to Perform
+
+### 1. hacs.json
+
+Verify required fields are present and valid:
+
+- `name` (string)
+- `homeassistant` (valid version string, e.g. "2024.8.0")
+- `render_readme` (boolean)
+
+### 2. manifest.json (`custom_components/rixens/manifest.json`)
+
+Verify required keys:
+
+- `domain`, `name`, `version`, `documentation`, `issue_tracker`
+- `codeowners` (non-empty list)
+- `requirements` (list)
+- `iot_class`
+- `version` follows semver (e.g. "1.2.3", no "v" prefix)
+
+### 3. Translations (`custom_components/rixens/translations/en.json`)
+
+- File exists and is valid JSON
+- All steps and fields referenced in `config_flow.py` have corresponding entries
+- No orphaned translation keys (keys with no matching config flow usage)
+
+### 4. Brand Assets
+
+- Check for icon/logo files or brand references
+- Verify any referenced brand assets exist
+
+### 5. Repository Hygiene
+
+- No `__pycache__` directories in tracked files
+- No `.pyc` files in tracked files
+- `.gitignore` excludes common Python artifacts
+
+## Output
+
+Provide a checklist-style report:
+
+- ✅ Passing checks with brief confirmation
+- ❌ Failing checks with specific file, line, and remediation
+- ⚠️ Warnings for non-blocking issues

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,23 @@
+You are a security reviewer for a Home Assistant custom integration that
+connects to Rixens RV heating/climate control systems.
+
+## Focus Areas
+
+- Credential storage and handling — no plaintext secrets in logs or state
+- Input validation on XML API responses from the device
+- OWASP top 10 issues relevant to IoT device integrations
+- Home Assistant config entry security (sensitive fields marked correctly)
+- HTTP communication security (the device uses unauthenticated HTTP)
+- Command injection risks in CGI parameter construction
+
+## Files to Review
+
+- `custom_components/rixens/api.py` — HTTP API client with XML parsing
+- `custom_components/rixens/config_flow.py` — device IP/port input handling
+- `custom_components/rixens/__init__.py` — setup and teardown
+- `custom_components/rixens/coordinator.py` — data polling
+
+## Output
+
+Provide a prioritized list of findings with severity (Critical / High / Medium /
+Low) and specific remediation suggestions.

--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+
+prettier --write "$FILE_PATH" 2>/dev/null
+exit 0

--- a/.claude/hooks/lint.sh
+++ b/.claude/hooks/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+
+# Only lint Python files
+echo "$FILE_PATH" | grep -qE '\.py$' || exit 0
+
+ruff check --fix "$FILE_PATH" 2>/dev/null
+exit 0

--- a/.claude/hooks/typecheck.sh
+++ b/.claude/hooks/typecheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+
+# Only type-check Python files
+echo "$FILE_PATH" | grep -qE '\.py$' || exit 0
+
+/opt/homebrew/bin/pyright "$FILE_PATH" 2>/dev/null
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,58 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.file_path' | grep -qE '\\.(env|secret|key)$' && echo 'BLOCKED: Cannot edit secret files' && exit 1; exit 0",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/format.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/lint.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/typecheck.sh",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/format.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/lint.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/typecheck.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: test
+description: Run the integration test suite
+user-invocable: true
+---
+
+Run the test suite for this Home Assistant integration.
+
+## Behavior
+
+- With no arguments: `pytest tests/ -v --cov=custom_components/rixens`
+- With a test file name argument (e.g., `/test api`):
+  `pytest tests/test_{arg}.py -v`
+- With a specific test function (e.g., `/test test_api.py::test_login_success`):
+  `pytest tests/{arg} -v`
+
+Report a concise pass/fail summary when done.

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: validate
+description: Run all CI validations locally before pushing
+user-invocable: true
+---
+
+Run the same validations that CI performs, to catch issues before pushing.
+
+## Steps
+
+1. **Manifest validation**: Verify `custom_components/rixens/manifest.json` is
+   valid JSON and contains required keys (`domain`, `name`, `version`,
+   `documentation`, `issue_tracker`, `codeowners`, `config_flow`, `iot_class`)
+2. **Test suite**: Run `pytest tests/ -v --cov=custom_components/rixens`
+3. **Lint check**: Run `ruff check custom_components/ tests/` (if ruff is
+   available)
+
+Report a summary of all results and whether it looks safe to push.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,37 @@
+name: Validate
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  validate-hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+
+  validate-hassfest:
+    name: Hassfest Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements_dev.txt -r requirements_test.txt
+      - run:
+          pytest tests/ -v --cov=custom_components/rixens --cov-report=xml
+          --cov-report=term-missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,12 @@ custom_components/rixens/
 The Rixens device exposes an HTTP API:
 
 **Status endpoint:** `GET /status.xml` - Returns XML with all device state
+
 - All temperature values are in **tenths of a degree Celsius** (e.g., 171 = 17.1°C)
 - Home Assistant handles display unit conversion based on user preferences
 
 **Control endpoints:** All use GET requests
+
 - `/interface.cgi?act=1&val=XXX` - Set temperature setpoint (in tenths of °C)
 - `/interface.cgi?act=2&val=XXX` - Set fan speed (10-100, or 999 for auto)
 - `/interface.cgi?act=4&val=0|1` - Electric heat on/off
@@ -49,22 +51,54 @@ The Rixens device exposes an HTTP API:
 
 ## Platforms
 
-| Platform | Entities |
-|----------|----------|
-| climate  | Main thermostat (setpoint, current temp, fan modes, HVAC modes) |
+| Platform | Entities                                                                                         |
+| -------- | ------------------------------------------------------------------------------------------------ |
+| climate  | Main thermostat (setpoint, current temp, fan modes, HVAC modes)                                  |
 | sensor   | Temperature, humidity, battery voltage, flame/inlet/outlet temps, altitude, runtime, diagnostics |
-| switch   | Furnace, fan, floor heat, electric heat |
-| number   | Fan speed (10-100%) |
+| switch   | Furnace, fan, floor heat, electric heat                                                          |
+| number   | Fan speed (10-100%)                                                                              |
 
 ## Development
 
 **Testing in Home Assistant:**
+
 1. Copy `custom_components/rixens/` to your HA `config/custom_components/` directory
 2. Restart Home Assistant
 3. Add integration via Settings > Devices & Services > Add Integration > Rixens
 4. Enter device IP address (port defaults to 80)
 
 **Adding new controls:**
+
 1. Add API method in `api.py`
 2. Add entity description in appropriate platform file
 3. Add translation key in `strings.json` and `translations/en.json`
+
+## Dev Commands
+
+- **Test:** `pytest tests/ -v --cov=custom_components/rixens`
+- **Lint:** `ruff check custom_components/`
+- **Format:** `ruff format custom_components/`
+- **Type-check:** `/opt/homebrew/bin/pyright custom_components/`
+
+## Testing
+
+- Tests live in `tests/` and mirror the module structure of `custom_components/rixens/`
+- 90% code coverage threshold enforced by CI
+- Use `aioresponses` for HTTP-level mocking
+- See `CONTRIBUTING.md` for full testing requirements and patterns
+
+## Code Navigation — Prefer Serena MCP Tools
+
+When exploring or reading code in this project, **prefer Serena MCP tools** over
+Read/Grep/Glob:
+
+- `get_symbols_overview` — get a file's classes, functions, and methods without
+  reading the full file
+- `find_symbol` — locate a symbol by name path (e.g. `RixensApi/get_status`),
+  optionally with `include_body=True`
+- `find_referencing_symbols` — find all callers/users of a symbol before
+  modifying it
+- `search_for_pattern` — fast regex search across the codebase
+
+Only fall back to Read/Grep/Glob when working with non-code files (JSON, YAML,
+markdown) or when you need raw file content that isn't organized into symbols.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing to Rixens Home Assistant Integration
+
+## Branch Strategy
+
+- **`main`** — Stable, release-ready code. Every commit on `main` should be
+  installable via HACS without issues.
+- **`dev`** — Active development branch. All new work happens here first.
+
+## Workflow
+
+1. Create a feature or fix branch off `dev`:
+
+   ```bash
+   git checkout dev
+   git pull
+   git checkout -b my-feature
+   ```
+
+2. Make your changes and commit.
+3. Open a pull request targeting `dev`.
+4. Once reviewed and merged into `dev`, changes are tested there before being
+   promoted.
+5. When `dev` is stable and ready for release, a PR is opened from `dev` →
+   `main` and tagged with a version.
+
+## Releases
+
+Releases are created from `main` using GitHub Releases. Each release gets a git
+tag matching the version in `manifest.json` (e.g., `v0.1.0`). HACS picks up new
+releases automatically.
+
+To cut a release:
+
+1. Merge `dev` → `main` via PR.
+2. Update `version` in `custom_components/rixens/manifest.json`.
+3. Create a GitHub Release with the tag (e.g., `v0.2.0`) and release notes.
+
+## Testing Requirements
+
+**All new code must be covered by tests.** This is a hard requirement for any PR
+to be merged.
+
+### Rules
+
+- Every new function, method, branch, and error path must have at least one
+  test.
+- Bug fixes must include a regression test that would have caught the bug.
+- Tests live in `tests/` and mirror the module structure of
+  `custom_components/rixens/` (e.g., `api.py` → `tests/test_api.py`).
+- The project enforces a minimum of **90% code coverage** (line + branch). The
+  CI pipeline will fail if coverage drops below this threshold.
+
+### Running tests locally
+
+```bash
+pip install -r requirements_dev.txt -r requirements_test.txt
+pytest tests/ -v --cov=custom_components/rixens --cov-report=term-missing
+```
+
+The `--cov-report=term-missing` flag prints uncovered lines so you can see
+exactly what still needs a test.
+
+### What to test
+
+| Area              | What to cover                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| `api.py`          | Every public method, every exception type raised, every branch (e.g., missing fields, XML parse errors) |
+| `coordinator.py`  | Setup, update, error paths, and the `data is None` initialisation branches                       |
+| `config_flow.py`  | All error cases (`cannot_connect`, `unknown`), duplicate-device abort, reconfigure flow          |
+| `sensor.py`       | Each entity property, unique ID format, and edge cases (missing data fields)                     |
+| `switch.py`       | Each switch entity, turn on/off actions, state extraction                                        |
+| `climate.py`      | HVAC modes, fan modes, temperature setting, state properties                                     |
+| `number.py`       | Fan speed slider value, set_value action                                                         |
+| `__init__.py`     | Setup success, connection failure, unload                                                        |
+
+### Test patterns
+
+Use shared fixtures in `tests/conftest.py` (`mock_coordinator`, `mock_api`,
+etc.) rather than duplicating setup logic in individual test files. When you need
+HTTP-level mocking, use `aioresponses`.
+
+## Testing a Branch on Your Home Assistant Install
+
+You can point your HA instance at any branch or PR to test changes before
+they're released.
+
+### Option 1: HACS Custom Repository (easiest)
+
+If you've already added this repo as a HACS custom repository, HACS installs
+from the latest release on `main` by default. To test a different branch:
+
+1. SSH into your HA instance or use the Terminal add-on.
+2. Navigate to the integration directory:
+
+   ```bash
+   cd /config/custom_components/rixens
+   ```
+
+3. Replace it with a git checkout of the branch:
+
+   ```bash
+   rm -rf /config/custom_components/rixens
+   git clone -b my-feature https://github.com/tailgatelabs/ha-rixens-integration.git /tmp/rixens-repo
+   cp -r /tmp/rixens-repo/custom_components/rixens /config/custom_components/rixens
+   rm -rf /tmp/rixens-repo
+   ```
+
+4. Restart Home Assistant.
+
+### Option 2: Direct Copy
+
+1. Clone the repo on your development machine:
+
+   ```bash
+   git clone https://github.com/tailgatelabs/ha-rixens-integration.git
+   cd ha-rixens-integration
+   git checkout dev  # or any branch/PR
+   ```
+
+2. Copy the integration to your HA config directory (via scp, Samba share,
+   etc.):
+
+   ```bash
+   scp -r custom_components/rixens user@homeassistant:/config/custom_components/
+   ```
+
+3. Restart Home Assistant.
+
+### Reverting to the Released Version
+
+To go back to the stable HACS-managed version:
+
+1. Delete the `custom_components/rixens` directory.
+2. Reinstall via HACS.
+3. Restart Home Assistant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["custom_components/rixens"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": ["custom_components"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.14",
+  "typeCheckingMode": "basic"
+}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+homeassistant
+voluptuous
+aiohttp

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+pytest>=8.0
+pytest-asyncio>=0.23
+pytest-homeassistant-custom-component>=0.13
+pytest-cov>=5.0
+aioresponses>=0.7


### PR DESCRIPTION
## Summary

- **Claude Code hooks**: PreToolUse blocks editing secret files; PostToolUse runs Prettier format, Ruff lint, and Pyright typecheck on every Write/Edit
- **Claude Code agents**: security-reviewer (rixens-specific: XML parsing, HTTP without auth, CGI params) and hacs-reviewer (HACS compliance checklist)
- **Claude Code skills**: `/validate` (manifest + pytest + ruff) and `/test` (pytest with argument patterns)
- **GitHub Actions CI**: HACS validation, hassfest validation, and pytest with coverage on push/PR to `dev`
- **Testing config**: pyproject.toml (pytest + 90% coverage threshold), pyrightconfig.json, requirements_dev.txt, requirements_test.txt
- **CONTRIBUTING.md**: Branch strategy, testing requirements, HA testing instructions
- **CLAUDE.md**: Added dev commands, testing conventions, and Serena MCP tool preferences

## Test plan

- [ ] Verify hooks fire on file edits (make a test edit to a `.py` file)
- [ ] Run `ruff check custom_components/` to verify lint setup
- [ ] Run `/opt/homebrew/bin/pyright custom_components/` to verify type checking
- [ ] Invoke `/validate` skill to test the skill definition
- [ ] Push to `dev` and verify GitHub Actions workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)