### PR TITLE
Fix fan mode control to match device protocol

### DIFF
--- a/custom_components/rixens/climate.py
+++ b/custom_components/rixens/climate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -21,16 +22,24 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    DEVICE_FAN_AUTO,
+    DEVICE_FAN_OFF,
     DOMAIN,
-    FAN_SPEED_AUTO,
+    FAN_MODE_AUTO,
+    FAN_MODE_OFF,
     FAN_SPEED_MAX,
     FAN_SPEED_MIN,
+    FAN_SPEED_STEP,
     TEMP_MAX,
     TEMP_MIN,
 )
 from .coordinator import RixensCoordinator
 
-FAN_MODES = ["auto", "10", "20", "30", "40", "50", "60", "70", "80", "90", "100"]
+_LOGGER = logging.getLogger(__name__)
+
+FAN_MODES = [FAN_MODE_OFF, FAN_MODE_AUTO] + [
+    str(s) for s in range(FAN_SPEED_MIN, FAN_SPEED_MAX + 1, FAN_SPEED_STEP)
+]
 
 # Default preset temperatures (can be customized via integration options)
 DEFAULT_PRESET_TEMPS = {
@@ -176,9 +185,19 @@ class RixensClimate(CoordinatorEntity[RixensCoordinator], ClimateEntity):
             return None
 
         fan_speed = self.coordinator.data.settings.fan_speed
-        if fan_speed == "Auto" or fan_speed == str(FAN_SPEED_AUTO):
-            return "auto"
-        return fan_speed
+        if fan_speed == DEVICE_FAN_OFF:
+            return FAN_MODE_OFF
+        if fan_speed == DEVICE_FAN_AUTO:
+            return FAN_MODE_AUTO
+        # Numeric value — snap to nearest valid step
+        try:
+            speed = int(fan_speed)
+            clamped = max(FAN_SPEED_MIN, min(FAN_SPEED_MAX, speed))
+            snapped = round(clamped / FAN_SPEED_STEP) * FAN_SPEED_STEP
+            return str(snapped)
+        except (ValueError, TypeError):
+            _LOGGER.warning("Unexpected fan speed value from device: %s", fan_speed)
+            return FAN_MODE_AUTO
 
     @property
     def preset_mode(self) -> str | None:
@@ -241,13 +260,20 @@ class RixensClimate(CoordinatorEntity[RixensCoordinator], ClimateEntity):
         await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
-        """Set new fan mode."""
-        if fan_mode == "auto":
-            await self.coordinator.api.set_fan_speed(FAN_SPEED_AUTO)
+        """Set new fan mode.
+
+        Off/auto use the fan on/off control (act=8).
+        Manual speeds use the fan speed control (act=2).
+        """
+        if fan_mode == FAN_MODE_OFF:
+            await self.coordinator.api.set_fan(False)
+        elif fan_mode == FAN_MODE_AUTO:
+            await self.coordinator.api.set_fan(True)
         else:
             speed = int(fan_mode)
-            if FAN_SPEED_MIN <= speed <= FAN_SPEED_MAX:
-                await self.coordinator.api.set_fan_speed(speed)
+            if not FAN_SPEED_MIN <= speed <= FAN_SPEED_MAX:
+                return
+            await self.coordinator.api.set_fan_speed(speed)
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/custom_components/rixens/const.py
+++ b/custom_components/rixens/const.py
@@ -10,10 +10,17 @@ CONF_PORT = "port"
 DEFAULT_PORT = 80
 
 # Fan speed constants
-FAN_SPEED_AUTO = 999
 FAN_SPEED_MIN = 10
 FAN_SPEED_MAX = 100
 FAN_SPEED_STEP = 10
+
+# Fan mode values reported by the device XML (<fanspeed> element)
+DEVICE_FAN_OFF = "Off"
+DEVICE_FAN_AUTO = "Auto"
+
+# Fan mode values used in the HA climate entity
+FAN_MODE_OFF = "off"
+FAN_MODE_AUTO = "auto"
 
 # Temperature constants (Celsius)
 TEMP_MIN = 5

--- a/custom_components/rixens/number.py
+++ b/custom_components/rixens/number.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, FAN_SPEED_AUTO, FAN_SPEED_MAX, FAN_SPEED_MIN, FAN_SPEED_STEP
+from .const import DEVICE_FAN_AUTO, DEVICE_FAN_OFF, DOMAIN, FAN_SPEED_MAX, FAN_SPEED_MIN, FAN_SPEED_STEP
 from .coordinator import RixensCoordinator
 
 
@@ -46,11 +46,11 @@ class RixensFanSpeed(CoordinatorEntity[RixensCoordinator], NumberEntity):
         )
 
     def _is_auto_mode(self) -> bool:
-        """Check if fan is in auto mode."""
+        """Check if fan is in auto or off mode (not manual speed)."""
         if not self.coordinator.data:
             return False
         fan_speed = self.coordinator.data.settings.fan_speed
-        return fan_speed == "Auto" or fan_speed == str(FAN_SPEED_AUTO)
+        return fan_speed in (DEVICE_FAN_AUTO, DEVICE_FAN_OFF)
 
     @property
     def native_value(self) -> float | None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -15,7 +15,6 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_TEMPERATURE
 
 from custom_components.rixens.climate import RixensClimate
-from custom_components.rixens.const import FAN_SPEED_AUTO
 
 from .conftest import make_rixens_data
 
@@ -122,13 +121,13 @@ class TestHvacAction:
 class TestFanMode:
     """Tests for fan mode property."""
 
-    def test_auto_mode_string(self, mock_coordinator):
-        mock_coordinator.data = make_rixens_data(fan_speed="Auto")
+    def test_off_mode(self, mock_coordinator):
+        mock_coordinator.data = make_rixens_data(fan_speed="Off")
         climate = RixensClimate(mock_coordinator)
-        assert climate.fan_mode == "auto"
+        assert climate.fan_mode == "off"
 
-    def test_auto_mode_numeric(self, mock_coordinator):
-        mock_coordinator.data = make_rixens_data(fan_speed=str(FAN_SPEED_AUTO))
+    def test_auto_mode(self, mock_coordinator):
+        mock_coordinator.data = make_rixens_data(fan_speed="Auto")
         climate = RixensClimate(mock_coordinator)
         assert climate.fan_mode == "auto"
 
@@ -136,6 +135,24 @@ class TestFanMode:
         mock_coordinator.data = make_rixens_data(fan_speed="50")
         climate = RixensClimate(mock_coordinator)
         assert climate.fan_mode == "50"
+
+    def test_manual_speed_snapped(self, mock_coordinator):
+        """Non-standard speed is snapped to nearest valid step."""
+        mock_coordinator.data = make_rixens_data(fan_speed="47")
+        climate = RixensClimate(mock_coordinator)
+        assert climate.fan_mode == "50"
+
+    def test_manual_speed_clamped_low(self, mock_coordinator):
+        """Speed below minimum is clamped to minimum."""
+        mock_coordinator.data = make_rixens_data(fan_speed="3")
+        climate = RixensClimate(mock_coordinator)
+        assert climate.fan_mode == "10"
+
+    def test_unparseable_falls_back_to_auto(self, mock_coordinator):
+        """Unexpected string value falls back to auto."""
+        mock_coordinator.data = make_rixens_data(fan_speed="unknown")
+        climate = RixensClimate(mock_coordinator)
+        assert climate.fan_mode == "auto"
 
     def test_none_when_no_data(self, mock_coordinator):
         mock_coordinator.data = None
@@ -229,10 +246,17 @@ class TestClimateActions:
         mock_coordinator.api.set_furnace.assert_awaited_with(False)
         mock_coordinator.api.set_electric_heat.assert_awaited_with(False)
 
+    async def test_set_fan_mode_off(self, mock_coordinator):
+        climate = RixensClimate(mock_coordinator)
+        await climate.async_set_fan_mode("off")
+        mock_coordinator.api.set_fan.assert_awaited_once_with(False)
+        mock_coordinator.api.set_fan_speed.assert_not_awaited()
+
     async def test_set_fan_mode_auto(self, mock_coordinator):
         climate = RixensClimate(mock_coordinator)
         await climate.async_set_fan_mode("auto")
-        mock_coordinator.api.set_fan_speed.assert_awaited_once_with(FAN_SPEED_AUTO)
+        mock_coordinator.api.set_fan.assert_awaited_once_with(True)
+        mock_coordinator.api.set_fan_speed.assert_not_awaited()
 
     async def test_set_fan_mode_manual(self, mock_coordinator):
         climate = RixensClimate(mock_coordinator)
@@ -240,10 +264,11 @@ class TestClimateActions:
         mock_coordinator.api.set_fan_speed.assert_awaited_once_with(50)
 
     async def test_set_fan_mode_out_of_range(self, mock_coordinator):
-        """Fan speed outside valid range is not sent."""
+        """Fan speed outside valid range is not sent and no refresh is triggered."""
         climate = RixensClimate(mock_coordinator)
         await climate.async_set_fan_mode("5")
         mock_coordinator.api.set_fan_speed.assert_not_awaited()
+        mock_coordinator.async_request_refresh.assert_not_awaited()
 
     async def test_set_preset_mode(self, mock_coordinator):
         climate = RixensClimate(mock_coordinator)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from custom_components.rixens.const import FAN_SPEED_AUTO, FAN_SPEED_MAX, FAN_SPEED_MIN
+from custom_components.rixens.const import FAN_SPEED_MAX, FAN_SPEED_MIN
 from custom_components.rixens.number import RixensFanSpeed
 
 from .conftest import make_rixens_data
@@ -33,8 +33,8 @@ class TestIsAutoMode:
         entity = RixensFanSpeed(mock_coordinator)
         assert entity._is_auto_mode() is True
 
-    def test_auto_numeric(self, mock_coordinator):
-        mock_coordinator.data = make_rixens_data(fan_speed=str(FAN_SPEED_AUTO))
+    def test_off_string(self, mock_coordinator):
+        mock_coordinator.data = make_rixens_data(fan_speed="Off")
         entity = RixensFanSpeed(mock_coordinator)
         assert entity._is_auto_mode() is True
 


### PR DESCRIPTION
## Summary
- **Fixes #51**: Fan auto/off now use `act=8` (fan on/off control) instead of `act=2` (speed control), matching the legacy UI behavior
- Handle `"Off"` fan speed value from device XML, adding "off" as a valid fan mode
- Replace magic strings with constants (`DEVICE_FAN_OFF`, `DEVICE_FAN_AUTO`, `FAN_MODE_OFF`, `FAN_MODE_AUTO`)
- Derive `FAN_MODES` list from constants instead of hardcoding
- Snap unexpected numeric fan speeds to nearest valid step, log warning for unparseable values
- Skip unnecessary coordinator refresh when fan speed is out of range

## Test plan
- [x] All 166 existing tests pass
- [x] New tests for off mode, speed snapping, clamping, unparseable fallback
- [x] Verified no-op refresh is skipped for out-of-range speeds
- [ ] Manual test on device: set fan to off, auto, and manual speeds via HA climate card

🤖 Generated with [Claude Code](https://claude.com/claude-code)