### PR TITLE
Fix fan mode protocol: turn fan on before setting speed/auto

### DIFF
--- a/custom_components/rixens/climate.py
+++ b/custom_components/rixens/climate.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     FAN_MODE_AUTO,
     FAN_MODE_OFF,
+    FAN_SPEED_AUTO,
     FAN_SPEED_MAX,
     FAN_SPEED_MIN,
     FAN_SPEED_STEP,
@@ -262,17 +263,20 @@ class RixensClimate(CoordinatorEntity[RixensCoordinator], ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode.
 
-        Off/auto use the fan on/off control (act=8).
-        Manual speeds use the fan speed control (act=2).
+        Off: turn fan off (act=8, val=0).
+        Auto: turn fan on (act=8, val=1), then set auto speed (act=2, val=999).
+        Manual: turn fan on (act=8, val=1), then set speed (act=2, val=N).
         """
         if fan_mode == FAN_MODE_OFF:
             await self.coordinator.api.set_fan(False)
         elif fan_mode == FAN_MODE_AUTO:
             await self.coordinator.api.set_fan(True)
+            await self.coordinator.api.set_fan_speed(FAN_SPEED_AUTO)
         else:
             speed = int(fan_mode)
             if not FAN_SPEED_MIN <= speed <= FAN_SPEED_MAX:
                 return
+            await self.coordinator.api.set_fan(True)
             await self.coordinator.api.set_fan_speed(speed)
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/rixens/const.py
+++ b/custom_components/rixens/const.py
@@ -13,6 +13,7 @@ DEFAULT_PORT = 80
 FAN_SPEED_MIN = 10
 FAN_SPEED_MAX = 100
 FAN_SPEED_STEP = 10
+FAN_SPEED_AUTO = 999
 
 # Fan mode values reported by the device XML (<fanspeed> element)
 DEVICE_FAN_OFF = "Off"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -256,11 +256,12 @@ class TestClimateActions:
         climate = RixensClimate(mock_coordinator)
         await climate.async_set_fan_mode("auto")
         mock_coordinator.api.set_fan.assert_awaited_once_with(True)
-        mock_coordinator.api.set_fan_speed.assert_not_awaited()
+        mock_coordinator.api.set_fan_speed.assert_awaited_once_with(999)
 
     async def test_set_fan_mode_manual(self, mock_coordinator):
         climate = RixensClimate(mock_coordinator)
         await climate.async_set_fan_mode("50")
+        mock_coordinator.api.set_fan.assert_awaited_once_with(True)
         mock_coordinator.api.set_fan_speed.assert_awaited_once_with(50)
 
     async def test_set_fan_mode_out_of_range(self, mock_coordinator):


### PR DESCRIPTION
## Summary
- Fix fan mode control to match device protocol: always send `set_fan(True)` (act=8, val=1) before setting speed or auto mode
- **Auto mode**: now sends `set_fan(True)` then `set_fan_speed(999)` (was missing the speed command)
- **Manual speed**: now sends `set_fan(True)` then `set_fan_speed(N)` (was missing the fan-on command)
- Add `FAN_SPEED_AUTO = 999` constant

## Test plan
- [x] Updated `test_set_fan_mode_auto` to assert both `set_fan(True)` and `set_fan_speed(999)` are called
- [x] Updated `test_set_fan_mode_manual` to assert both `set_fan(True)` and `set_fan_speed(50)` are called
- [x] All 166 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)