### PR TITLE
Add effective fan speed sensor for dashboard tiles

### DIFF
--- a/custom_components/rixens/sensor.py
+++ b/custom_components/rixens/sensor.py
@@ -52,14 +52,14 @@ def _compute_fan_speed(data: RixensData) -> int:
 
     Returns 0 when fan is off, PID speed in auto mode, or configured speed in manual.
     """
+    if not data.settings.fan_state:
+        return 0
     fan_speed = data.settings.fan_speed
     if fan_speed == DEVICE_FAN_OFF:
         return 0
     if fan_speed == DEVICE_FAN_AUTO:
         pid = data.heater.pid_speed
-        if pid == 0:
-            return 0
-        return max(FAN_SPEED_MIN, min(FAN_SPEED_MAX, pid))
+        return min(FAN_SPEED_MAX, max(0, pid))
     try:
         speed = int(fan_speed)
         return max(FAN_SPEED_MIN, min(FAN_SPEED_MAX, speed))

--- a/custom_components/rixens/sensor.py
+++ b/custom_components/rixens/sensor.py
@@ -27,7 +27,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import RixensData
-from .const import CONF_FUEL_DOSE, DEFAULT_FUEL_DOSE, DOMAIN
+from .const import (
+    CONF_FUEL_DOSE,
+    DEFAULT_FUEL_DOSE,
+    DEVICE_FAN_AUTO,
+    DEVICE_FAN_OFF,
+    DOMAIN,
+    FAN_SPEED_MAX,
+    FAN_SPEED_MIN,
+)
 from .coordinator import RixensCoordinator
 
 
@@ -36,6 +44,27 @@ class RixensSensorEntityDescription(SensorEntityDescription):
     """Describes a Rixens sensor entity."""
 
     value_fn: Callable[[RixensData], float | int | str | None]
+    icon_fn: Callable[[float | int | str | None], str] | None = None
+
+
+def _compute_fan_speed(data: RixensData) -> int:
+    """Compute effective fan speed across all modes.
+
+    Returns 0 when fan is off, PID speed in auto mode, or configured speed in manual.
+    """
+    fan_speed = data.settings.fan_speed
+    if fan_speed == DEVICE_FAN_OFF:
+        return 0
+    if fan_speed == DEVICE_FAN_AUTO:
+        pid = data.heater.pid_speed
+        if pid == 0:
+            return 0
+        return max(FAN_SPEED_MIN, min(FAN_SPEED_MAX, pid))
+    try:
+        speed = int(fan_speed)
+        return max(FAN_SPEED_MIN, min(FAN_SPEED_MAX, speed))
+    except ValueError:
+        return 0
 
 
 SENSOR_DESCRIPTIONS: tuple[RixensSensorEntityDescription, ...] = (
@@ -168,6 +197,14 @@ SENSOR_DESCRIPTIONS: tuple[RixensSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.heat_version,
     ),
+    RixensSensorEntityDescription(
+        key="effective_fan_speed",
+        translation_key="effective_fan_speed",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_compute_fan_speed,
+        icon_fn=lambda val: "mdi:fan-off" if val == 0 else "mdi:fan",
+    ),
 )
 
 
@@ -201,6 +238,13 @@ class RixensSensor(CoordinatorEntity[RixensCoordinator], SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
         )
+
+    @property
+    def icon(self) -> str | None:
+        """Return a dynamic icon if the description provides icon_fn."""
+        if self.entity_description.icon_fn is not None:
+            return self.entity_description.icon_fn(self.native_value)
+        return None
 
     @property
     def native_value(self) -> float | int | str | None:

--- a/custom_components/rixens/strings.json
+++ b/custom_components/rixens/strings.json
@@ -86,6 +86,9 @@
       },
       "heat_firmware_version": {
         "name": "Heat firmware version"
+      },
+      "effective_fan_speed": {
+        "name": "Fan speed"
       }
     },
     "switch": {

--- a/custom_components/rixens/switch.py
+++ b/custom_components/rixens/switch.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api import RixensApi, RixensData
 from .const import DOMAIN
 from .coordinator import RixensCoordinator
+from .sensor import _compute_fan_speed
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -25,6 +26,7 @@ class RixensSwitchEntityDescription(SwitchEntityDescription):
     value_fn: Callable[[RixensData], bool]
     turn_on_fn: Callable[[RixensApi], Awaitable[None]]
     turn_off_fn: Callable[[RixensApi], Awaitable[None]]
+    extra_attr_fn: Callable[[RixensData], dict[str, Any]] | None = None
 
 
 SWITCH_DESCRIPTIONS: tuple[RixensSwitchEntityDescription, ...] = (
@@ -55,6 +57,7 @@ SWITCH_DESCRIPTIONS: tuple[RixensSwitchEntityDescription, ...] = (
         value_fn=lambda data: data.settings.fan_state,
         turn_on_fn=lambda api: api.set_fan(True),
         turn_off_fn=lambda api: api.set_fan(False),
+        extra_attr_fn=lambda data: {"fan_speed": _compute_fan_speed(data)},
     ),
     RixensSwitchEntityDescription(
         key="continuous_heat",
@@ -102,6 +105,13 @@ class RixensSwitch(CoordinatorEntity[RixensCoordinator], SwitchEntity):
         """Return True if the switch is on."""
         if self.coordinator.data:
             return self.entity_description.value_fn(self.coordinator.data)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra state attributes."""
+        if self.coordinator.data and self.entity_description.extra_attr_fn:
+            return self.entity_description.extra_attr_fn(self.coordinator.data)
         return None
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/rixens/translations/en.json
+++ b/custom_components/rixens/translations/en.json
@@ -86,6 +86,9 @@
       },
       "heat_firmware_version": {
         "name": "Heat firmware version"
+      },
+      "effective_fan_speed": {
+        "name": "Fan speed"
       }
     },
     "switch": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -155,9 +155,9 @@ class TestComputeFanSpeed:
         data = make_rixens_data(fan_speed="Auto", pid_speed=0)
         assert _compute_fan_speed(data) == 0
 
-    def test_auto_pid_clamped_low(self):
+    def test_auto_pid_low(self):
         data = make_rixens_data(fan_speed="Auto", pid_speed=3)
-        assert _compute_fan_speed(data) == 10
+        assert _compute_fan_speed(data) == 3
 
     def test_auto_pid_clamped_high(self):
         data = make_rixens_data(fan_speed="Auto", pid_speed=150)
@@ -177,4 +177,14 @@ class TestComputeFanSpeed:
 
     def test_invalid_value(self):
         data = make_rixens_data(fan_speed="bogus")
+        assert _compute_fan_speed(data) == 0
+
+    def test_fan_state_off_returns_zero(self):
+        """Fan switch off should return 0 regardless of fan_speed setting."""
+        data = make_rixens_data(fan_speed="70", fan_state=False)
+        assert _compute_fan_speed(data) == 0
+
+    def test_fan_state_off_auto_returns_zero(self):
+        """Fan switch off in auto mode should return 0 regardless of PID speed."""
+        data = make_rixens_data(fan_speed="Auto", pid_speed=50, fan_state=False)
         assert _compute_fan_speed(data) == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,6 +11,7 @@ from custom_components.rixens.sensor import (
     SENSOR_DESCRIPTIONS,
     RixensSensor,
     RixensSensorEntityDescription,
+    _compute_fan_speed,
 )
 
 from .conftest import make_rixens_data
@@ -101,3 +102,79 @@ class TestSensorEntity:
         for desc in SENSOR_DESCRIPTIONS:
             sensor = RixensSensor(mock_coordinator, desc)
             assert sensor.native_value is not None
+
+    def test_effective_fan_speed_auto_mode(self, mock_coordinator):
+        """In auto mode, effective fan speed returns PID speed."""
+        mock_coordinator.data = make_rixens_data(fan_speed="Auto", pid_speed=73)
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.native_value == 73
+
+    def test_effective_fan_speed_auto_pid_zero(self, mock_coordinator):
+        """In auto mode with PID=0, effective fan speed returns 0."""
+        mock_coordinator.data = make_rixens_data(fan_speed="Auto", pid_speed=0)
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.native_value == 0
+
+    def test_effective_fan_speed_off(self, mock_coordinator):
+        """When fan is off, effective fan speed returns 0."""
+        mock_coordinator.data = make_rixens_data(fan_speed="Off")
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.native_value == 0
+
+    def test_effective_fan_speed_manual(self, mock_coordinator):
+        """In manual mode, effective fan speed returns configured speed."""
+        mock_coordinator.data = make_rixens_data(fan_speed="50")
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.native_value == 50
+
+    def test_effective_fan_speed_icon_off(self, mock_coordinator):
+        """Icon shows fan-off when speed is 0."""
+        mock_coordinator.data = make_rixens_data(fan_speed="Off")
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.icon == "mdi:fan-off"
+
+    def test_effective_fan_speed_icon_on(self, mock_coordinator):
+        """Icon shows fan when speed > 0."""
+        mock_coordinator.data = make_rixens_data(fan_speed="Auto", pid_speed=73)
+        sensor = self._make_sensor(mock_coordinator, "effective_fan_speed")
+        assert sensor.icon == "mdi:fan"
+
+
+class TestComputeFanSpeed:
+    """Tests for the _compute_fan_speed helper function."""
+
+    def test_fan_off(self):
+        data = make_rixens_data(fan_speed="Off")
+        assert _compute_fan_speed(data) == 0
+
+    def test_auto_with_pid(self):
+        data = make_rixens_data(fan_speed="Auto", pid_speed=50)
+        assert _compute_fan_speed(data) == 50
+
+    def test_auto_pid_zero(self):
+        data = make_rixens_data(fan_speed="Auto", pid_speed=0)
+        assert _compute_fan_speed(data) == 0
+
+    def test_auto_pid_clamped_low(self):
+        data = make_rixens_data(fan_speed="Auto", pid_speed=3)
+        assert _compute_fan_speed(data) == 10
+
+    def test_auto_pid_clamped_high(self):
+        data = make_rixens_data(fan_speed="Auto", pid_speed=150)
+        assert _compute_fan_speed(data) == 100
+
+    def test_manual_speed(self):
+        data = make_rixens_data(fan_speed="70")
+        assert _compute_fan_speed(data) == 70
+
+    def test_manual_clamped_low(self):
+        data = make_rixens_data(fan_speed="5")
+        assert _compute_fan_speed(data) == 10
+
+    def test_manual_clamped_high(self):
+        data = make_rixens_data(fan_speed="200")
+        assert _compute_fan_speed(data) == 100
+
+    def test_invalid_value(self):
+        data = make_rixens_data(fan_speed="bogus")
+        assert _compute_fan_speed(data) == 0

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -119,6 +119,16 @@ class TestSwitchEntity:
         switch = self._make_switch(mock_coordinator, "fan")
         assert switch.is_on is False
 
+    def test_fan_extra_attrs_on(self, mock_coordinator):
+        mock_coordinator.data = make_rixens_data(fan_state=True, fan_speed="70")
+        switch = self._make_switch(mock_coordinator, "fan")
+        assert switch.extra_state_attributes == {"fan_speed": 70}
+
+    def test_fan_extra_attrs_off(self, mock_coordinator):
+        mock_coordinator.data = make_rixens_data(fan_state=False, fan_speed="70")
+        switch = self._make_switch(mock_coordinator, "fan")
+        assert switch.extra_state_attributes == {"fan_speed": 0}
+
     async def test_fan_turn_on(self, mock_coordinator):
         switch = self._make_switch(mock_coordinator, "fan")
         await switch.async_turn_on()


### PR DESCRIPTION
## Summary

- Add `effective_fan_speed` sensor that computes the actual fan speed across all modes (off/auto/manual), respecting the fan switch state
- Fan switch entity now exposes `fan_speed` as an extra state attribute, enabling the dashboard tile card to use the switch for on/off color/icon while displaying the computed speed percentage
- Auto mode reports full 0–100 PID range; manual mode clamps to 10–100 to match slider constraints

## Details

**New sensor (`sensor.py`):**
- `_compute_fan_speed()` returns 0 when fan is off (`fan_state=False` or speed setting is "Off"), PID speed (0–100) in auto mode, or configured speed (10–100) in manual mode
- Dynamic icon via `icon_fn`: `mdi:fan-off` when 0, `mdi:fan` otherwise

**Fan switch attribute (`switch.py`):**
- Added `extra_attr_fn` to `RixensSwitchEntityDescription` for optional extra state attributes
- Fan switch exposes `fan_speed` attribute computed by `_compute_fan_speed`
- Dashboard tile uses `switch.heating_fan` as primary entity (for on/off icon + color) with `state_content: fan_speed` to display the speed value

## Test plan

- [x] `_compute_fan_speed` unit tests cover: fan_state off, speed "Off", auto with PID (0, low, normal, high), manual (normal, clamped low/high), invalid value
- [x] Sensor entity tests cover: auto mode, auto PID zero, off, manual, icon off, icon on
- [x] Switch extra_state_attributes tests cover: fan on with speed, fan off returns 0
- [x] All 185 tests passing
- [ ] Deploy to HA and verify tile card shows correct icon/color/value

🤖 Generated with [Claude Code](https://claude.com/claude-code)